### PR TITLE
level fail 이벤트 구현

### DIFF
--- a/Assets/Scripts/PlayerBehaviour.cs
+++ b/Assets/Scripts/PlayerBehaviour.cs
@@ -8,7 +8,7 @@ public class PlayerBehaviour : MonoBehaviour
     [SerializeField] private Grid obstacleGrid;
     [SerializeField] private float cooldown = 0.5f;
 
-    private int life = 5;
+    private int life = 3;
 
     private Tilemap _obstacleTilemap;
     private bool _isInCooldown;

--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class StageManager : MonoBehaviour
 {
@@ -34,6 +35,6 @@ public class StageManager : MonoBehaviour
 
     public void GameOver()
     {
-        Debug.Log("Game Over");
+        SceneManager.LoadScene("LevelOverScene");
     }
 }


### PR DESCRIPTION
resolves #51 

- StageManager에서 Gameover()가 불리면 LevelOverScene을 로드하도록 변경
- Player의 life를 5에서 3으로 변경