### PR TITLE
실시간점수, 최종점수 계산

### DIFF
--- a/Assets/Scenes/TestMap.unity
+++ b/Assets/Scenes/TestMap.unity
@@ -1007,7 +1007,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18b5aeff1216346c1855556c68b9df00, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  goalZ: 0
+  goalZ: 24.5
 --- !u!4 &102563352
 Transform:
   m_ObjectHideFlags: 0
@@ -5580,6 +5580,7 @@ MonoBehaviour:
   cooldown: 0.5
   moveSpeed: 2
   rotationSpeed: 10
+  referenceSpeed: 0.5
 --- !u!114 &466761509
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -23483,23 +23484,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   trashGrid: {fileID: 2048045676}
   trashMapping: {fileID: 11400000, guid: c6844e95e016d374c9c1664efff4c6fa, type: 2}
-  trashMappings:
-  - markerTile: {fileID: 11400000, guid: b2e52e1a2409aad4da2fba4387f09a09, type: 2}
-    trashPrefabs:
-    - {fileID: 796257223966090764, guid: 2c3d49b69fc8f7842a825b84e27519b0, type: 3}
-    - {fileID: 438391252229260795, guid: 0f74cf45fb5965b4da43a134e0fa0c44, type: 3}
-  - markerTile: {fileID: 11400000, guid: 0c42540ed39726b46b063104d042f2b5, type: 2}
-    trashPrefabs:
-    - {fileID: 406528671913698738, guid: 916f455adc8cf414fa4fd606d0163d19, type: 3}
-  - markerTile: {fileID: 11400000, guid: b3e5db6f2614d9d44aeb807785d13d84, type: 2}
-    trashPrefabs:
-    - {fileID: 243947998393874717, guid: f1bbb369b830ac549930c10548904463, type: 3}
-    - {fileID: 1868390095917243043, guid: 86d22b2b2f30f194fa102cdd1e6d5f86, type: 3}
-  - markerTile: {fileID: 11400000, guid: 765a9a7ff7e231d49b9acace99ae84ea, type: 2}
-    trashPrefabs:
-    - {fileID: 2379069296815962343, guid: cfbe2ef680cb38a4aaedd3d210392349, type: 3}
-    - {fileID: 4673554988342177545, guid: 61b4924217e7eb543ab39f13fb34fb68, type: 3}
-    - {fileID: 5382996660327333013, guid: 977488ddf2a8ebc4780c8e2fdae40ebf, type: 3}
 --- !u!1 &1921616599
 GameObject:
   m_ObjectHideFlags: 0
@@ -27263,6 +27247,7 @@ MonoBehaviour:
   cooldown: 0.5
   moveSpeed: 2
   rotationSpeed: 10
+  referenceSpeed: 0.5
 --- !u!1001 &6977969051665533655
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ActiveLevelData.cs
+++ b/Assets/Scripts/ActiveLevelData.cs
@@ -8,4 +8,9 @@ public class ActiveLevelData
         this.level = level;
         this.score = 0;
     }
+    public ActiveLevelData(int level, int score)
+    {
+        this.level = level;
+        this.score = score;
+    }
 }

--- a/Assets/Scripts/PlayerBehaviour.cs
+++ b/Assets/Scripts/PlayerBehaviour.cs
@@ -21,6 +21,7 @@ public class PlayerBehaviour : MonoBehaviour
 
     private const float _respawnZAdd = 7.0f;
     private const float _respawnX = 7.5f;
+    [SerializeField] private float referenceSpeed = 0.5f;
 
     private float goalZ;
 
@@ -29,7 +30,10 @@ public class PlayerBehaviour : MonoBehaviour
         _obstacleTilemap = obstacleGrid.GetComponentInChildren<Tilemap>();
         _animator = GetComponent<Animator>();
         _targetPosition = transform.position;
+
         goalZ = StageManager.Instance.GetGoalZ();
+        float _startZ = transform.position.z;
+        ScoreModel.Instance = new ScoreModel(_startZ, referenceSpeed);
     }
 
     /// <summary>
@@ -57,6 +61,17 @@ public class PlayerBehaviour : MonoBehaviour
                 _isWalking = false;
                 _animator.SetBool("isWalking", false);
             }
+        }
+
+        ScoreModel.Instance.UpdateScore(transform.position.z);
+
+        if (transform.position.z >= goalZ)
+        {
+            int level = DataManager.Instance.GetActiveLevelData().level;
+            int score = ScoreModel.Instance.CalculateFinalScore(transform.position.z);
+            ActiveLevelData levelClearData = new ActiveLevelData(level, score);
+            DataManager.Instance.SetActiveLevelData(levelClearData);
+            StageManager.Instance.GameClear();
         }
     }
 
@@ -89,21 +104,13 @@ public class PlayerBehaviour : MonoBehaviour
         _animator.SetTrigger("triggerPickUp");
 
     }
-    /// <summary>
-    /// Updates player's position.
-    /// </summary>
-    /// <param name="direction">Direction which player moves to.</param>
-    public void UpdatePos(Direction direction)
-    {
-        transform.position += direction.Value;
-        if (transform.position.z >= goalZ) StageManager.Instance.GameClear();
-    }
 
     private IEnumerator CooldownRoutine()
     {
         yield return new WaitForSeconds(cooldown);
         _isInCooldown = false;
     }
+
 
     private void DecreaseLife()
     {
@@ -113,6 +120,8 @@ public class PlayerBehaviour : MonoBehaviour
         if (life <= 0)
             StageManager.Instance.GameOver();
     }
+
+
 
     public void Respawn()
     {

--- a/Assets/Scripts/ScoreModel.cs
+++ b/Assets/Scripts/ScoreModel.cs
@@ -1,0 +1,58 @@
+
+using UnityEngine;
+
+public class ScoreModel
+{
+    // ScoreUI scoreUI;
+    private float startTime;
+    private float startZ;
+    private float referenceSpeed;
+    private int trashDisposeCount;
+    private int trashMissCount;
+    private int trashPickupCount;
+
+    public static ScoreModel Instance;
+
+    public ScoreModel(float startZ, float referenceSpeed)
+    {
+        startTime = Time.time;
+        this.startZ = startZ;
+        this.referenceSpeed = referenceSpeed;
+    }
+
+
+    public int CalculateFinalScore(float currentZ)
+    {
+        float offsetZ = currentZ - startZ;
+        float referenceTime = offsetZ / referenceSpeed;
+        float playTime = Time.time - startTime;
+        float clampedTimeScore = Mathf.Clamp(referenceTime - playTime, -20.0f, 20.0f);
+        return (int)(clampedTimeScore + 5 * (trashPickupCount + trashDisposeCount - trashMissCount) + 100);
+    }
+
+    public void UpdateScore(float currentZ)
+    {
+        float offsetZ = currentZ - startZ;
+        float referenceTime = offsetZ / referenceSpeed;
+        float playTime = Time.time - startTime;
+        int score = (int)(referenceTime - playTime + 5 * (trashPickupCount + trashDisposeCount - trashMissCount));
+        Debug.Log(score);
+        // scoreUI.UpdateScore(score);
+    }
+
+    public void IncTrashPickupCount()
+    {
+        ++trashPickupCount;
+    }
+
+    public void IncTrashDisposeCount()
+    {
+        ++trashDisposeCount;
+    }
+
+    public void IncTrashMissCount()
+    {
+        ++trashMissCount;
+    }
+
+}

--- a/Assets/Scripts/ScoreModel.cs.meta
+++ b/Assets/Scripts/ScoreModel.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: af207c8fc80a400f96a4fe5cb5d6d230
+timeCreated: 1732704284

--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -8,6 +8,7 @@ public class StageManager : MonoBehaviour
 {
     private static StageManager instance;
     [SerializeField] private float goalZ;
+
     public static StageManager Instance
     {
         get

--- a/Assets/Scripts/TrashPicker.cs
+++ b/Assets/Scripts/TrashPicker.cs
@@ -30,6 +30,11 @@ public class TrashPicker : MonoBehaviour
         var trashPosOnTilemap = _trashTilemap.WorldToCell(trashObject.transform.position);
         Destroy(trashObject);
         _trashTilemap.SetTile(trashPosOnTilemap, null);
+        if (ScoreModel.Instance != null)
+        {
+            ScoreModel.Instance.IncTrashPickupCount();
+        }
+
     }
 
     private GameObject FindTrashAtCurrentPos()

--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -1,7 +1,7 @@
 {
-  "m_Name": "Settings",
-  "m_Path": "ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json",
-  "m_Dictionary": {
-    "m_DictionaryValues": []
-  }
+    "m_Name": "Settings",
+    "m_Path": "ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json",
+    "m_Dictionary": {
+        "m_DictionaryValues": []
+    }
 }

--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -1,7 +1,7 @@
 {
-    "m_Name": "Settings",
-    "m_Path": "ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json",
-    "m_Dictionary": {
-        "m_DictionaryValues": []
-    }
+  "m_Name": "Settings",
+  "m_Path": "ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json",
+  "m_Dictionary": {
+    "m_DictionaryValues": []
+  }
 }


### PR DESCRIPTION
# 실시간점수, 최종점수 계산

## Related Issue(s)
resolves #66

## PR Description
- PlayerBehaviour에서, 실시간 점수와 최종점수를 계산하는 로직을 추가
- (실시간 점수) = (현재 지점의 기준 시간) - (현재시간)+ 5 * (버린 쓰레기 개수)
- (최종 점수) = clamp((현재 지점의 기준 시간)- (플레이 시간) , -20, 20) + 5 * ((버린 쓰레기 개수) - (전체 쓰레기 개수)) + 100

_원래 프로젝트 제안서에는 <(플레이 시간) - (현재 지점의 기준 시간)>으로 계산을 하도록 되어있었는데, <(현재 지점의 기준 시간) - (현재시간)> 이쪽이 더 자연스러운것 같아서(빨리 갈 수록 점수가 높아짐) 변경하였습니다._

- 버린 쓰레기 개수, 전체 쓰레기 개수는 추후에  반영

### Changes Included
- [x] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation

### Screenshots (if UI changes were made)
Attach screenshots or GIFs of any visual changes. (Only for frontend-related changes)

### Notes for Reviewer
Any specific instructions or points to be considered by the reviewer.

---

## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Manual testing has been performed to ensure the PR works as expected. 
- [ ] Code review comments have been addressed or clarified.

---

## Additional Comments
Add any other comments or information that might be useful for the review process.
