### PR TITLE
Fix trashMapping

### DIFF
--- a/Assets/Scripts/PlayerBehaviour.cs
+++ b/Assets/Scripts/PlayerBehaviour.cs
@@ -44,7 +44,7 @@ public class PlayerBehaviour : MonoBehaviour
         _animator = GetComponent<Animator>();
         _targetPosition = transform.position;
         _targetDirection = Vector3.zero;
-        _trashMapping = FindObjectOfType<TrashSpawner>().trashMapping;
+        _trashMapping = Resources.Load("Storages/TrashMapping") as TrashMapping;
 
         goalZ = StageManager.Instance.GetGoalZ();
         float _startZ = transform.position.z;

--- a/Assets/Scripts/TrashSpawner.cs
+++ b/Assets/Scripts/TrashSpawner.cs
@@ -51,6 +51,7 @@ public class TrashSpawner : MonoBehaviour
     {
         _trashTilemap = trashGrid.GetComponentInChildren<Tilemap>();
         _gridInformation = trashGrid.GetComponent<GridInformation>();
+        trashMapping = Resources.Load("Storages/TrashMapping") as TrashMapping;
 
         InitialSpawn();
         _trashTilemap.GetComponent<TilemapRenderer>().enabled = false;

--- a/Assets/Scripts/TrashSpawner.cs
+++ b/Assets/Scripts/TrashSpawner.cs
@@ -5,7 +5,7 @@ public class TrashSpawner : MonoBehaviour
 {
     private GameObject[] _trashes;
     [SerializeField] private Grid trashGrid;
-    [SerializeField]
+
     public TrashMapping trashMapping
     {
         get; private set;


### PR DESCRIPTION
# Fix trashMapping

## Related Issue(s)



## PR Description

ScriptableObject를 옮긴 이후로 쓰레기가 제대로 로드되지 않는 버그가 있습니다.

### Changes Included

- [x] SerializeField 제거
- [x] `Resources.Load()`로 TrashMapping 불러오기

### Notes for Reviewer

Any specific instructions or points to be considered by the reviewer.

---

## Reviewer Checklist

- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

---

## Additional Comments

Add any other comments or information that might be useful for the review process.
