### PR TITLE
레벨 1 스카이박스 넣기

### DIFF
--- a/Assets/Scenes/LevelOneScene.unity
+++ b/Assets/Scenes/LevelOneScene.unity
@@ -26,7 +26,7 @@ RenderSettings:
   m_AmbientIntensity: 1
   m_AmbientMode: 0
   m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
-  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_SkyboxMaterial: {fileID: 2100000, guid: f2b5f3f20933f434e850db1b710542fd, type: 2}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
   m_FlareFadeSpeed: 3
@@ -7752,17 +7752,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   musicSource: {fileID: 514516225}
   sfxSource: {fileID: 514516225}
-  musicClip: {fileID: 8300000, guid: 5ebbe520d33e94e24a2cb4c3303a17a8, type: 3}
-  sfxClips:
-  - {fileID: 8300000, guid: 7390242c56c0f415e890dd99613ca53b, type: 3}
-  - {fileID: 8300000, guid: b4ef42cd99dcd4236a9ae0f38aacd14b, type: 3}
-  - {fileID: 8300000, guid: a6271c6ee967a4eb2a7367b9024bbb55, type: 3}
-  - {fileID: 8300000, guid: 04f37d69565b44276a1ba2c903f78202, type: 3}
-  - {fileID: 8300000, guid: 89166699b72e649a391c1cc8d454874e, type: 3}
-  - {fileID: 8300000, guid: 7ea99cd1cbd6d4797a84945c49d3b858, type: 3}
-  - {fileID: 8300000, guid: 1c442e764fdd04ea68c382d9a7ca40e2, type: 3}
-  - {fileID: 8300000, guid: 5a538b46c328949799e430407dc73c95, type: 3}
-  - {fileID: 8300000, guid: 211996ab31c1b4d8ca6df1289a0beca7, type: 3}
 --- !u!4 &514516227
 Transform:
   m_ObjectHideFlags: 0
@@ -24934,7 +24923,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   trashGrid: {fileID: 2048045676}
-  trashMapping: {fileID: 11400000, guid: c6844e95e016d374c9c1664efff4c6fa, type: 2}
 --- !u!1001 &1915313883
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -1,7 +1,7 @@
 {
-  "m_Name": "Settings",
-  "m_Path": "ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json",
-  "m_Dictionary": {
-    "m_DictionaryValues": []
-  }
+    "m_Name": "Settings",
+    "m_Path": "ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json",
+    "m_Dictionary": {
+        "m_DictionaryValues": []
+    }
 }

--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -1,7 +1,7 @@
 {
-    "m_Name": "Settings",
-    "m_Path": "ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json",
-    "m_Dictionary": {
-        "m_DictionaryValues": []
-    }
+  "m_Name": "Settings",
+  "m_Path": "ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json",
+  "m_Dictionary": {
+    "m_DictionaryValues": []
+  }
 }


### PR DESCRIPTION
# LevelOneScene Skybox 적용

## Related Issue(s)

Resolves #126 

## PR Description

Added skybox to level one scene (same as StartScene and SelectLevelScene)
Free asset from Unity Asset Store. [Link](https://assetstore.unity.com/packages/2d/textures-materials/sky/allsky-free-10-sky-skybox-set-146014)
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/75378968-6f8f-41d0-89ea-8f8f9f82739b">

### Changes Included

- [ ] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation

### Screenshots (if UI changes were made)

Attach screenshots or GIFs of any visual changes. (Only for frontend-related changes)
<img width="904" alt="image" src="https://github.com/user-attachments/assets/49465e50-1734-4e86-a587-72d10f8eb97e">


### Notes for Reviewer

Any specific instructions or points to be considered by the reviewer.

---

## Reviewer Checklist

- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

---

## Additional Comments

Add any other comments or information that might be useful for the review process.
