### PR TITLE
level 선택 버그 수정

### DIFF
--- a/Assets/Scenes/LevelSelectScene.unity
+++ b/Assets/Scenes/LevelSelectScene.unity
@@ -984,7 +984,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 457264041}
   m_OnClick:
     m_PersistentCalls:
@@ -2107,7 +2107,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 935521742}
   m_OnClick:
     m_PersistentCalls:
@@ -3757,7 +3757,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 1897772222}
   m_OnClick:
     m_PersistentCalls:


### PR DESCRIPTION
# level 선택 버그 수정

## Related Issue(s)
Resolves #142 

## PR Description
- LevelSelectScene에서 level 버튼들의 기본으로 Interactable이 활성화되어있어서 일어난 버그였습니다.

### Changes Included
- LevelSelectScene 버튼 Interactable 옵션 변경

### Screenshots (if UI changes were made)

Attach screenshots or GIFs of any visual changes. (Only for frontend-related changes)

### Notes for Reviewer

Any specific instructions or points to be considered by the reviewer.

---

## Reviewer Checklist

- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.

---

## Additional Comments

Add any other comments or information that might be useful for the review process.
